### PR TITLE
Prépare la liste des TPs

### DIFF
--- a/content/listeTP/_index.md
+++ b/content/listeTP/_index.md
@@ -1,0 +1,41 @@
+---
+title: "Travaux dirigés"
+date: 2020-09-10T13:00:00Z
+draft: false
+weight: 80
+---
+
+La liste des travaux dirigés, sous forme d'exercices approfondis, peut être
+trouvée ci-dessous. A chaque fois, le premier lien renvoie vers la page
+dédiée sur ce site, la seconde vers le notebook dans le dépôt github et les
+boutons permettent de lancer ces notebooks dans un environnement
+temporaire (voir [ici](configuration))
+
+Séance 1:
+
+* [Des rappels généraux sur les objets en python](rappels2A)
+<a href="https://github.com/linogaliana/python-datascientist/blob/master/content/getting-started/04_rappels_types.ipynb" class="github"><i class="fab fa-github"></i></a>
+[![nbviewer](https://img.shields.io/badge/visualize-nbviewer-blue)](https://nbviewer.jupyter.org/github/linogaliana/python-datascientist/blob/master/content/getting-started/04_rappels_types.ipynb)
+[![Onyxia](https://img.shields.io/badge/launch-onyxia-brightgreen)](https://spyrales.sspcloud.fr/my-lab/catalogue/inseefrlab-datascience/jupyter/deploiement)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/linogaliana/python-datascientist/master?filepath=content/getting-started/04_rappels_types.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](http://colab.research.google.com/github/linogaliana/python-datascientist/blob/master/content/getting-started/04_rappels_types.ipynb)
+* [Des rappels sur les fonctions en python](rappelsfonctions)
+<a href="https://github.com/linogaliana/python-datascientist/blob/master/content/getting-started/04_rappels_fonctions.ipynb" class="github"><i class="fab fa-github"></i></a>
+[![nbviewer](https://img.shields.io/badge/visualize-nbviewer-blue)](https://nbviewer.jupyter.org/github/linogaliana/python-datascientist/blob/master/content/getting-started/04_rappels_fonctions.ipynb)
+[![Onyxia](https://img.shields.io/badge/launch-onyxia-brightgreen)](https://spyrales.sspcloud.fr/my-lab/catalogue/inseefrlab-datascience/jupyter/deploiement)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/linogaliana/python-datascientist/master?filepath=content/getting-started/04_rappels_fonctions.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](http://colab.research.google.com/github/linogaliana/python-datascientist/blob/master/content/getting-started/04_rappels_fonctions.ipynb)
+* [Un TD (optionnel) sur les classes en python](rappelsclasses)
+<a href="https://github.com/linogaliana/python-datascientist/blob/master/content/getting-started/04_rappels_classes.ipynb" class="github"><i class="fab fa-github"></i></a>
+[![nbviewer](https://img.shields.io/badge/visualize-nbviewer-blue)](https://nbviewer.jupyter.org/github/linogaliana/python-datascientist/blob/master/content/getting-started/04_rappels_classes.ipynb)
+[![Onyxia](https://img.shields.io/badge/launch-onyxia-brightgreen)](https://spyrales.sspcloud.fr/my-lab/catalogue/inseefrlab-datascience/jupyter/deploiement)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/linogaliana/python-datascientist/master?filepath=content/getting-started/04_rappels_classes.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](http://colab.research.google.com/github/linogaliana/python-datascientist/blob/master/content/getting-started/04_rappels_classes.ipynb)
+
+Les notebooks d'exercices sont accessible dans 
+<a href="https://github.com/linogaliana/python-datascientist" class="github"><i class="fab fa-github"></i></a>
+et dans les différents environnements prêts à l'emploi mis à
+disposition
+[![Onyxia](https://img.shields.io/badge/launch-onyxia-brightgreen)](https://spyrales.sspcloud.fr/my-lab/catalogue/inseefrlab-datascience/jupyter/deploiement)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/linogaliana/python-datascientist/master)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](http://colab.research.google.com/github/linogaliana/python-datascientist/blob/pandas_intro/static/notebooks/numpy.ipynb)


### PR DESCRIPTION
Un onglet dédié à la liste des TPs permettant de ne pas chercher dans l'arborescence complexe du site