### PR TITLE
fix and simplify pyinsee install

### DIFF
--- a/content/course/manipulation/02a_pandas_tutorial.Rmd
+++ b/content/course/manipulation/02a_pandas_tutorial.Rmd
@@ -68,10 +68,6 @@ Pour essayer les exemples présents dans ce tutoriel :
 ```{r, echo = FALSE, results = 'asis', include = TRUE, eval = TRUE}
 print_badges()
 ```
-
-Le [chapitre suivant](#pandasTP) permettra de pratiquer plus amplement les
-concepts
-
 Dans ce tutoriel `pandas`, nous allons utiliser:
 
 * Les émissions de gaz à effet de serre estimées au niveau communal par l'ADEME. Le jeu de données est 
@@ -79,7 +75,7 @@ disponible sur [data.gouv](https://www.data.gouv.fr/fr/datasets/inventaire-de-ga
 et requêtable directement dans `Python` avec
 [cet url](https://koumoul.com/s/data-fair/api/v1/datasets/igt-pouvoir-de-rechauffement-global/convert)
 
-Le chapitre suivant permettra de mettre en application des éléments présents dans ce chapitre avec
+Le [chapitre suivant](#pandasTP) permettra de mettre en application des éléments présents dans ce chapitre avec
 les données ci-dessus associées à des données de contexte au niveau communal[^1].
 
 
@@ -103,30 +99,18 @@ pip install git+https://github.com/InseeFrLab/Py-Insee-Data.git
 Cependant, cela implique que `Jupyter` et `Git` sont capables de communiquer. Si
 `Jupyter` ne sait pas où trouver `Git`, il est possible de rencontrer une erreur.
 
-Dans ce cas, il faut télécharger le package en `zip`, le `dézipper` et l'installer
-depuis ce dossier dézippé. Pour les deux premières étapes, on peut utiliser 
-les commandes suivantes:
+Dans ce cas, il faut télécharger le package compressé et l'installer localement : 
 
 ```{python, eval = FALSE}
 import requests
-import zipfile
 
 url = 'https://github.com/InseeFrLab/Py-Insee-Data/archive/refs/heads/master.zip'
 r = requests.get(url)
-open("pynsee.zip" , 'wb').write(r.content)
+with open("pynsee.zip" , 'wb') as zipfile:
+    zipfile.write(r.content)
 
-with zipfile.ZipFile("pynsee.zip", 'r') as zip_ref:
-  zip_ref.extractall("pynsee")
-```
-
-Cela ajoute un dossier `pynsee` dans le répertoire de travail. Pour installer
-ce package, il faut se rendre dans le dossier `pynsee` (par exemple avec la
-commande `cd`) et effectuer le `pip install` :
-
-```{shell, eval = FALSE}
-cd pynsee
-pip install -r requirements.txt
-pip install .
+!pip install --ignore-installed pynsee.zip
+!pip install python-Levenshtein
 ```
 
 Si le fait de ne pas avoir de barre de progrès lors du téléchargement
@@ -145,12 +129,6 @@ les commandes d'import avec le chemin adéquat plutôt que l'url.
 
 
 Nous suivrons les conventions habituelles dans l'import des packages
-
-```{python, show = FALSE, include = FALSE, eval = FALSE}
-# Get the development version from GitHub
-#!pip install python-Levenshtein
-#!pip install git+https://github.com/InseeFrLab/Py-Insee-Data.git
-```
 
 ```{python import pkg}
 import numpy as np

--- a/content/course/manipulation/02b_pandas_TP.Rmd
+++ b/content/course/manipulation/02b_pandas_TP.Rmd
@@ -64,29 +64,6 @@ Pour faciliter l'import de données Insee, il est recommandé d'utiliser le pack
 de l'Insee disponibles sur le site web [insee.fr](https://www.insee.fr/fr/accueil)
 ou via des API. 
 
-{{% panel status="note" title="Note" icon="fa fa-comment" %}}
-
-Idéalement, pour installer `pynsee` depuis le [dépôt Github](https://github.com/InseeFrLab/Py-Insee-Data), il est nécessaire
-de taper, dans une invite de commande,
-
-```shell
-pip install python-Levenshtein
-pip install git+https://github.com/InseeFrLab/Py-Insee-Data@master
-```
-
-Dans google colab, vous pouvez effectuer les instructions suivantes :
-
-```shell
-!pip install python-Levenshtein
-!pip install git+https://github.com/InseeFrLab/Py-Insee-Data.git
-```
-
-Cependant, il peut arriver des situations où `Jupyter` ne sait pas communiquer
-avec `Git` pour effectuer ce `pip install` particulier. Dans ce cas,
-se référer au [chapitre précédent](#pandas).
-
-{{% /panel %}}
-
 [^1]: Toute contribution sur ce package, disponible sur [Github](https://github.com/InseeFrLab/Py-Insee-Data) est bienvenue !
 
 Nous suivrons les conventions habituelles dans l'import des packages


### PR DESCRIPTION
Fix some bugs occuring when installing `pynsee` in Onyxia's Jupyter :
- add `--ignore-installed` to `pip install` to solve issue with PyYAML
- add install of `python-Levenshtein` to prevent missing error when loading `pynsee.download`

Simplify installation of pynsee
- use a context manager to download zip file
- install package directly from the .zip archive

Remove duplicated installation instructions.