### PR TITLE
store git credentials when prompted by jupyterlab-git extension

### DIFF
--- a/init_onyxia.sh
+++ b/init_onyxia.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Store git credentials when prompted (for jupyterlab-git extension)
+git config --global credential.helper store
+
+# Clone course repository
 git clone https://github.com/linogaliana/python-datascientist.git ~/python-datascientist
 cp -r ~/python-datascientist/notebooks/course/* /home/jovyan/work/
 chown -R jovyan:users /home/jovyan/work/


### PR DESCRIPTION
Make Git store credentials when prompted (which are stored as env variables in the pod anyway) to prevent having to type them at each action when using jupyterlab-git.